### PR TITLE
Allow for CloudFormation references on pathPattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ objects, the objects all have the same fields, each of which is explained here:
       * origin-request
       * viewer-response
       * origin-response
-   * **`pathPattern`** (optional): a string, the path pattern of one of the cache
-     behaviors in the specified distribution if you want this function to be associated
-     with a specific cache behavior. If the path pattern is not defined here, the function
-     will be associated with the default cache behavior for the specified distribution.
+   * **`pathPattern`** (optional): a string or CloudFormation reference to a string, the path
+     pattern of one of the cache behaviors in the specified distribution if you want this function
+     to be associated with a specific cache behavior. If the path pattern is not defined here, the
+     function will be associated with the default cache behavior for the specified distribution.
 
 You can also apply global properties by adding the `lambdaAtEdge` property to your
 `custom` section of your `serverless.yml`. **Note:** This section currently only supports

--- a/src/index.js
+++ b/src/index.js
@@ -141,13 +141,13 @@ module.exports = Class.extend({
 
       if (pathPattern) {
          // If an object is being passed in let's assume it's a reference
-         if(typeof pathPattern === 'object') {
-            pathPattern = pathPattern.Ref
+         if (typeof pathPattern === 'object') {
+            pathPattern = pathPattern.Ref;
             cacheBehavior = _.find(distConfig.CacheBehaviors, function(cb) {
-               return cb.PathPattern.Ref === pathPattern
-            })
+               return cb.PathPattern.Ref === pathPattern;
+            });
          } else {
-           cacheBehavior = _.findWhere(distConfig.CacheBehaviors, { PathPattern: pathPattern });
+            cacheBehavior = _.findWhere(distConfig.CacheBehaviors, { PathPattern: pathPattern });
          }
 
          if (!cacheBehavior) {

--- a/src/index.js
+++ b/src/index.js
@@ -140,10 +140,11 @@ module.exports = Class.extend({
       distConfig = dist.Properties.DistributionConfig;
 
       if (pathPattern) {
+         // If an object is being passed in let's assume it's a reference
          if(typeof pathPattern === 'object') {
             pathPattern = pathPattern.Ref
-            cacheBehavior = _.find(distConfig.CacheBehaviors, function(beh) {
-               return beh.PathPattern.Ref === pathPattern
+            cacheBehavior = _.find(distConfig.CacheBehaviors, function(cb) {
+               return cb.PathPattern.Ref === pathPattern
             })
          } else {
            cacheBehavior = _.findWhere(distConfig.CacheBehaviors, { PathPattern: pathPattern });

--- a/src/index.js
+++ b/src/index.js
@@ -140,7 +140,14 @@ module.exports = Class.extend({
       distConfig = dist.Properties.DistributionConfig;
 
       if (pathPattern) {
-         cacheBehavior = _.findWhere(distConfig.CacheBehaviors, { PathPattern: pathPattern });
+         if(typeof pathPattern === 'object') {
+            pathPattern = pathPattern.Ref
+            cacheBehavior = _.find(distConfig.CacheBehaviors, function(beh) {
+               return beh.PathPattern.Ref === pathPattern
+            })
+         } else {
+           cacheBehavior = _.findWhere(distConfig.CacheBehaviors, { PathPattern: pathPattern });
+         }
 
          if (!cacheBehavior) {
             throw new Error('Could not find cache behavior in "' + distName + '" with path pattern "' + pathPattern + '"');


### PR DESCRIPTION
This addresses an issue I came across while developing for a Serverless framework project. I had `Parameter` values to centralize the `pathPattern` as it was being used in the `Distribution` as well as some custom cfn functionality. I was unable to utilize the intrinsic `Ref` function to associate that `Parameter` value with this plugin as the plugin is only designed for explicit strings in the `pathParameter`. 

This {R makes the assumption that when an object is being passed in it is a `Ref` and should be treated like such, otherwise treat it as a normal string. This could potentially be expanded to include `GetAtt` values as well if the maintainer sees a potential advantage in that.

This is my first work on a Serverless type plugin, so if there are better ways to handle this I'm very happy to learn and adapt.