### PR TITLE
fix(config): 🐛 remove required lambdaAtEdge

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,6 @@ module.exports = Class.extend({
                ],
             },
          },
-         required: [ 'lambdaAtEdge' ],
       });
 
       this.hooks = {


### PR DESCRIPTION
Fixes the required warnings on none edge functions.

Closes #67 