### PR TITLE
Warn about versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ plugins:
    - '@silvermine/serverless-plugin-cloudfront-lambda-edge'
 ```
 
+⚠️ Be careful, **versioning function MUST BE ENABLED**. If you defined `versionFunctions: false`
+in your `serverless.yml` function, the plugin will raise an error during package/deploy 
+saying it could not find output by name.
+
 ### Configuring Functions to Associate With CloudFront Distributions
 
 Also in your `serverless.yml` file, you will modify your function definitions to include a


### PR DESCRIPTION
I've added a warning about versioning function.
Until https://github.com/silvermine/serverless-plugin-cloudfront-lambda-edge/issues/60 is closed, I think it's important to have that information in the readme.

I've tried to figure out a workaround when versioning is disabled but I can't find a way.